### PR TITLE
[FIX] security

### DIFF
--- a/medical_clinical_careplan/security/medical_security.xml
+++ b/medical_clinical_careplan/security/medical_security.xml
@@ -11,7 +11,6 @@
     <record id="group_medical_careplan_add_plan_definition" model="res.groups">
         <field name="name">Add plan definition on careplans</field>
         <field name="category_id" ref="base.module_category_hidden"/>
-        <field name="implied_ids" eval="[(4, ref('medical_workflow.group_workflow_plan_definition_display'))]"/>
     </record>
 
     <record id="group_medical_careplan_display" model="res.groups">


### PR DESCRIPTION
Fixes security. If the flag `group_medical_careplan_add_plan_definition` was selected, all user could see all the definitions menu