### PR TITLE
allow to select company_type in res.partner

### DIFF
--- a/medical_administration_practitioner/views/res_partner_views.xml
+++ b/medical_administration_practitioner/views/res_partner_views.xml
@@ -42,7 +42,7 @@
                 </div>
             </xpath>
             <field name="company_type" position="attributes">
-                <attribute name="attrs">{'invisible': True}</attribute>
+                <attribute name="attrs">{'invisible': [('is_practitioner','=',True)]}</attribute>
             </field>
         </field>
     </record>


### PR DESCRIPTION
Otherwise when entering to a supplier you get by default the person view, and cannot change to company.