### PR TITLE
[FIX] medical_base: added forgotten data file

### DIFF
--- a/medical_base/__manifest__.py
+++ b/medical_base/__manifest__.py
@@ -17,6 +17,7 @@
         "security/ir.model.access.csv",
         "views/res_partner.xml",
         "data/ir_sequence_data.xml",
+        "data/medical_role.xml",
         "views/medical_menu.xml",
         "views/medical_patient.xml",
         "views/res_config_settings_views.xml",


### PR DESCRIPTION
Durante la migración a 16 que se cambió la estructura de los módulos, se olvidó añadir este archivo data y está dando problemas con otros módulos que lo necesitan